### PR TITLE
use path format for public URL

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -1,15 +1,15 @@
 /*
-	Copyright 2015, Google, Inc. 
- Licensed under the Apache License, Version 2.0 (the "License"); 
- you may not use this file except in compliance with the License. 
- You may obtain a copy of the License at 
-  
-    http://www.apache.org/licenses/LICENSE-2.0 
-  
- Unless required by applicable law or agreed to in writing, software 
- distributed under the License is distributed on an "AS IS" BASIS, 
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- See the License for the specific language governing permissions and 
+	Copyright 2015, Google, Inc.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
  limitations under the License.
 */
 "use strict";
@@ -53,11 +53,11 @@ module.exports = function (gcloudConfig, cloudStorageBucket, logging) {
 
 
   /*
-    Returns the public, anonymously accessable URL to a given Cloud Storage object.
+    Returns the public, anonymously accessible URL to a given Cloud Storage object.
     The object's ACL has to be set to public read.
   */
   function getPublicUrl(filename) {
-    return 'https://' + cloudStorageBucket + '.storage.googleapis.com/' + filename;
+    return 'https://storage.googleapis.com/' + cloudStorageBucket + '/' + filename;
   }
 
 


### PR DESCRIPTION
This changes the public URL for a file in GCS to a safer alternative. Bucket names are allowed to hold `.` characters, which would result in an incorrect URL. We recently ran into this with gcloud: https://github.com/GoogleCloudPlatform/gcloud-node/pull/638.

I'll be sending 2 more PRs for the other branches as well.