### PR TITLE
Cache mongo collection

### DIFF
--- a/books/model-mongodb.js
+++ b/books/model-mongodb.js
@@ -22,6 +22,7 @@ module.exports = function(config) {
 
   var url = config.mongodb.url;
   var collectionName = config.mongodb.collection;
+  var collection;
 
 
   function fromMongo(item) {
@@ -39,12 +40,17 @@ module.exports = function(config) {
 
 
   function getCollection(cb) {
+    if (collection) {
+      setImmediate(function() { cb(null, collection); });
+      return;
+    }
     MongoClient.connect(url, function(err, db) {
       if (err) {
         console.log(err);
         return cb(err);
       }
-      cb(null, db.collection(collectionName));
+      collection = db.collection(collectionName);
+      cb(null, collection);
     });
   }
 


### PR DESCRIPTION
This avoids having to open a new mongo connection each time. The system quickly
runs out of resources if too many mongo connections are open at the same time.

This is probably needed on almost all the branches.