### PR TITLE
Add skip_files entry to app.yaml

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -36,3 +36,16 @@ automatic_scaling:
 
 env_variables:
   NODE_ENV: production
+
+# Temporary workaround for a Cloud SDK bug.
+# Ensures that node_modules directory and any .log files are not uploaded (the
+# other entries are the default values for skip_files). This will skip any Unix
+# hidden files (such as the .git directory)
+skip_files:
+ - ^(.*/)?#.*#$
+ - ^(.*/)?.*~$
+ - ^(.*/)?.*\.py[co]$
+ - ^(.*/)?.*/RCS/.*$
+ - ^(.*/)?\..*$
+ - ^(.*/)?.*/node_modules/.*$
+ - ^(.*/)?.*\.log$


### PR DESCRIPTION
This is a temporary work-around for a bug in the Cloud SDK [1], where the
node_modules directory is uploaded. Until this bug is fixed, this bug will
ensure that the 1-hello-world example deploys successfully.

Due to the bug in question, the node_modules directory was being uploaded. This
causes issues with the Docker build on Windows, and causes increased build times
in general.

[1] https://code.google.com/p/google-cloud-sdk/issues/detail?id=210