### PR TITLE
Update `backend-services add-backend` syntax

### DIFF
--- a/gce/deploy.sh
+++ b/gce/deploy.sh
@@ -104,7 +104,7 @@ gcloud compute backend-services create $SERVICE \
 
 # [START add_backend_service]
 gcloud compute backend-services add-backend $SERVICE \
-  --group $GROUP \
+  --instance-group $GROUP \
   --zone $ZONE
 # [END add_backend_service]
 


### PR DESCRIPTION
The `--group` flag changed to `--instance-group` in a recent build. The `--group` flag seems to work still, but `--instance-group` is preferable.