### PR TITLE
Fixing node version warning when deploying with gcloud.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   "license": "Apache Version 2.0",
   "dependencies": {
     "express": "^4.12.0"
+  },
+  "engines": {
+    "node": ">=0.10"
   }
 }


### PR DESCRIPTION
gcloud gives a warning about a missing node version:

> WARNING: No node version specified.  Please add your node version, see https://docs.npmjs.com/files/package.json#engines

This change fixes this for 1-hello-world-guided. This should be propagated to the other branches.

  