### PR TITLE
The error handler should log the stack trace instead of just the error message.

### DIFF
--- a/2-structured-data/app.js
+++ b/2-structured-data/app.js
@@ -42,7 +42,7 @@ app.use(function (req, res) {
 // Basic error handler
 app.use(function (err, req, res, next) {
   /* jshint unused:false */
-  console.error(err);
+  console.error(err.stack || err);
   // If our routes specified a specific response, then send that. Otherwise,
   // send a generic message so as not to leak anything.
   res.status(500).send(err.response || 'Something broke!');

--- a/3-binary-data/app.js
+++ b/3-binary-data/app.js
@@ -45,7 +45,7 @@ app.use(function (req, res) {
 // Basic error handler
 app.use(function (err, req, res, next) {
   /* jshint unused:false */
-  console.error(err);
+  console.error(err.stack || err);
   // If our routes specified a specific response, then send that. Otherwise,
   // send a generic message so as not to leak anything.
   res.status(500).send(err.response || 'Something broke!');

--- a/4-auth/app.js
+++ b/4-auth/app.js
@@ -61,7 +61,7 @@ app.use(function (req, res) {
 // Basic error handler
 app.use(function (err, req, res, next) {
   /* jshint unused:false */
-  console.error(err);
+  console.error(err.stack || err);
   // If our routes specified a specific response, then send that. Otherwise,
   // send a generic message so as not to leak anything.
   res.status(500).send(err.response || 'Something broke!');


### PR DESCRIPTION
This changes how errors are logged. The behavior of the current code is to log errors like so:
 [TypeError: Cannot read property 'someMethod' of undefined]

After merging this change, it will look much more useful, as follows:
TypeError: Cannot read property 'someMethod' of undefined
at /app/app.js:40:4
at Layer.handle [as handle_request](/app/node_modules/express/lib/router/layer.js:95:5)
at next (/app/node_modules/express/lib/router/route.js:131:13)
at Route.dispatch (/app/node_modules/express/lib/router/route.js:112:3)
at Layer.handle [as handle_request](/app/node_modules/express/lib/router/layer.js:95:5)
at /app/node_modules/express/lib/router/index.js:277:22
at Function.process_params (/app/node_modules/express/lib/router/index.js:330:12)
at next (/app/node_modules/express/lib/router/index.js:271:10)
at expressInit (/app/node_modules/express/lib/middleware/init.js:33:5)
at Layer.handle [as handle_request](/app/node_modules/express/lib/router/layer.js:95:5)
