### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/1-hello-world/package.json
+++ b/1-hello-world/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node app.js",
     "monitor": "nodemon app.js",
-    "deploy": "gcloud preview app deploy app.yaml",
+    "deploy": "gcloud app deploy app.yaml",
     "mocha": "mocha test/index.js -t 30000",
     "lint": "semistandard \"**/*.js\"",
     "test": "npm run lint && npm run mocha"

--- a/2-structured-data/package.json
+++ b/2-structured-data/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node app.js",
     "monitor": "nodemon app.js",
-    "deploy": "gcloud preview app deploy app.yaml",
+    "deploy": "gcloud app deploy app.yaml",
     "mocha": "mocha test/index.js -t 30000",
     "lint": "semistandard \"**/*.js\"",
     "test": "npm run lint && npm run mocha",

--- a/3-binary-data/package.json
+++ b/3-binary-data/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node app.js",
     "monitor": "nodemon app.js",
-    "deploy": "gcloud preview app deploy app.yaml",
+    "deploy": "gcloud app deploy app.yaml",
     "mocha": "mocha test/index.js -t 30000",
     "lint": "semistandard \"**/*.js\"",
     "test": "npm run lint && npm run mocha",

--- a/4-auth/package.json
+++ b/4-auth/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node app.js",
     "monitor": "nodemon app.js",
-    "deploy": "gcloud preview app deploy app.yaml",
+    "deploy": "gcloud app deploy app.yaml",
     "mocha": "mocha test/index.js -t 30000",
     "lint": "semistandard \"**/*.js\"",
     "test": "npm run lint && npm run mocha",

--- a/5-logging/package.json
+++ b/5-logging/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node app.js",
     "monitor": "nodemon app.js",
-    "deploy": "gcloud preview app deploy app.yaml",
+    "deploy": "gcloud app deploy app.yaml",
     "mocha": "mocha test/index.js -t 30000",
     "lint": "semistandard \"**/*.js\"",
     "test": "npm run lint && npm run mocha",

--- a/6-pubsub/package.json
+++ b/6-pubsub/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node ${SCRIPT:-app.js}",
     "monitor": "nodemon ${SCRIPT:-app.js}",
-    "deploy": "gcloud preview app deploy app.yaml worker.yaml",
+    "deploy": "gcloud app deploy app.yaml worker.yaml",
     "mocha": "mocha test/index.js -t 30000",
     "lint": "semistandard \"**/*.js\"",
     "test": "npm run lint && npm run mocha",

--- a/7-gce/package.json
+++ b/7-gce/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node ${SCRIPT:-app.js}",
     "monitor": "nodemon ${SCRIPT:-app.js}",
-    "deploy": "gcloud preview app deploy app.yaml worker.yaml",
+    "deploy": "gcloud app deploy app.yaml worker.yaml",
     "mocha": "mocha test/index.js -t 30000",
     "lint": "semistandard \"**/*.js\"",
     "test": "npm run lint && npm run mocha",

--- a/optional-container-engine/package.json
+++ b/optional-container-engine/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node ${SCRIPT:-app.js}",
     "monitor": "nodemon ${SCRIPT:-app.js}",
-    "deploy": "gcloud preview app deploy app.yaml worker.yaml",
+    "deploy": "gcloud app deploy app.yaml worker.yaml",
     "mocha": "mocha test/index.js -t 30000",
     "lint": "semistandard \"**/*.js\"",
     "test": "npm run lint && npm run mocha",


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.