### PR TITLE
Fix the worker deploy in 6-pubsub

### DIFF
--- a/6-pubsub/worker.yaml
+++ b/6-pubsub/worker.yaml
@@ -14,7 +14,7 @@
 # [START yaml]
 module: worker
 runtime: nodejs
-vm: true
+env: flex
 
 env_variables:
   SCRIPT: worker.js

--- a/7-gce/worker.yaml
+++ b/7-gce/worker.yaml
@@ -14,7 +14,7 @@
 # [START yaml]
 module: worker
 runtime: nodejs
-vm: true
+env: flex
 
 env_variables:
   SCRIPT: worker.js


### PR DESCRIPTION
The worker.yaml contains a deprecated config which results in a deploy
error. Following
https://cloud.google.com/appengine/docs/flexible/python/upgrading
```
vm: true
```
has to be change to
```
env: flex
```

Fixes GoogleCloudPlatform/nodejs-getting-started#95.