### PR TITLE
Update Node version in Kokoro tests

### DIFF
--- a/.kokoro/e2e-tests/build.sh
+++ b/.kokoro/e2e-tests/build.sh
@@ -18,6 +18,9 @@
 rm -rf */*.log
 rm -rf *-*.yaml
 
+# Install the latest version of Node 8
+nvm install 8
+
 export NODE_ENV=development
 export E2E_TESTS=true # test the deployed app
 


### PR DESCRIPTION
We need Node 8 as specified in the package.json.