### PR TITLE
Delete obsolete test

### DIFF
--- a/.kokoro/e2e-tests/mongodb/6_pubsub.cfg
+++ b/.kokoro/e2e-tests/mongodb/6_pubsub.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Specify which directory to test
-env_vars: {
-    key: "BOOKSHELF_DIRECTORY"
-    value: "6-pubsub"
-}


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/nodejs-getting-started/pull/155/files
deleted `model-mongodb.js`. This PR removes the test that is now
obsolete.