### PR TITLE
Fix flaky test failures due to OOMs

### DIFF
--- a/2-structured-data/app.yaml
+++ b/2-structured-data/app.yaml
@@ -16,4 +16,5 @@ runtime: nodejs8
 handlers:
 - url: /.*
   script: auto
-  
+
+instance_class: F2

--- a/3-binary-data/app.yaml
+++ b/3-binary-data/app.yaml
@@ -12,3 +12,5 @@
 # limitations under the License.
 #
 runtime: nodejs8
+
+instance_class: F2

--- a/4-auth/app.yaml
+++ b/4-auth/app.yaml
@@ -16,3 +16,5 @@ runtime: nodejs8
 handlers:
 - url: /.*
   script: auto
+
+instance_class: F2

--- a/5-logging/app.yaml
+++ b/5-logging/app.yaml
@@ -16,3 +16,5 @@ runtime: nodejs8
 handlers:
 - url: /.*
   script: auto
+
+instance_class: F2

--- a/6-pubsub/app.yaml
+++ b/6-pubsub/app.yaml
@@ -16,3 +16,5 @@ runtime: nodejs8
 handlers:
 - url: /.*
   script: auto
+
+instance_class: F2


### PR DESCRIPTION
Pub/Sub tests were failing due to OOM errors. This PR switches to `f2` instances (from the default `f1`s) to increase the amount of memory available.