### PR TITLE
Unbreak tests by fixing package.json files.

### DIFF
--- a/5-logging/package.json
+++ b/5-logging/package.json
@@ -79,7 +79,7 @@
     "@google-cloud/nodejs-repo-tools": "^2.3.5",
     "ava": "0.25.0",
     "proxyquire": "1.8.0",
-    "supertest": "^3.3.0"
+    "supertest": "^3.3.0",
     "sinon": "^4.5.0"
   },
   "engines": {

--- a/6-pubsub/package.json
+++ b/6-pubsub/package.json
@@ -83,7 +83,7 @@
     "@google-cloud/nodejs-repo-tools": "^2.3.5",
     "ava": "0.25.0",
     "proxyquire": "1.8.0",
-    "supertest": "^3.3.0"
+    "supertest": "^3.3.0",
     "sinon": "^4.5.0"
   },
   "engines": {

--- a/7-gce/package.json
+++ b/7-gce/package.json
@@ -83,7 +83,7 @@
     "@google-cloud/nodejs-repo-tools": "^2.3.5",
     "ava": "0.25.0",
     "proxyquire": "1.8.0",
-    "supertest": "^3.3.0"
+    "supertest": "^3.3.0",
     "sinon": "^4.5.0"
   },
   "engines": {


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/nodejs-getting-started/pull/187
appears to have been some kind of curated dependency update, but it
generated invalid JSON syntax causing test breakages.  This change
corrects the package.json structure for the affected files.