### PR TITLE
Update required Node.js version and cleanups

### DIFF
--- a/optional-kubernetes-engine/.dockerignore
+++ b/optional-kubernetes-engine/.dockerignore
@@ -1,4 +1,4 @@
-# Copyright 2015 Google Inc. All Rights Reserved.
+# Copyright 2018 Google Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/optional-kubernetes-engine/Dockerfile
+++ b/optional-kubernetes-engine/Dockerfile
@@ -3,9 +3,9 @@
 FROM gcr.io/google_appengine/nodejs
 
 # Check to see if the the version included in the base runtime satisfies
-# '>=0.12.7', if not then do an npm install of the latest available
+# '>=8.12.0', if not then do an npm install of the latest available
 # version that satisfies it.
-RUN /usr/local/bin/install_node '>=0.12.7'
+RUN /usr/local/bin/install_node '>=8.12.0'
 COPY . /app/
 
 # You have to specify "--unsafe-perm" with npm install

--- a/optional-kubernetes-engine/app.js
+++ b/optional-kubernetes-engine/app.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/books/api.js
+++ b/optional-kubernetes-engine/books/api.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/books/crud.js
+++ b/optional-kubernetes-engine/books/crud.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/books/model-cloudsql.js
+++ b/optional-kubernetes-engine/books/model-cloudsql.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/books/model-datastore.js
+++ b/optional-kubernetes-engine/books/model-datastore.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/books/model-mongodb.js
+++ b/optional-kubernetes-engine/books/model-mongodb.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/bookshelf-frontend-cloudsql.yaml
+++ b/optional-kubernetes-engine/bookshelf-frontend-cloudsql.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/optional-kubernetes-engine/bookshelf-frontend-datastore.yaml
+++ b/optional-kubernetes-engine/bookshelf-frontend-datastore.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/optional-kubernetes-engine/bookshelf-frontend-mongodb.yaml
+++ b/optional-kubernetes-engine/bookshelf-frontend-mongodb.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/optional-kubernetes-engine/bookshelf-service.yaml
+++ b/optional-kubernetes-engine/bookshelf-service.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/optional-kubernetes-engine/bookshelf-worker-cloudsql.yaml
+++ b/optional-kubernetes-engine/bookshelf-worker-cloudsql.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/optional-kubernetes-engine/bookshelf-worker-datastore.yaml
+++ b/optional-kubernetes-engine/bookshelf-worker-datastore.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/optional-kubernetes-engine/bookshelf-worker-mongodb.yaml
+++ b/optional-kubernetes-engine/bookshelf-worker-mongodb.yaml
@@ -1,4 +1,4 @@
-# Copyright 2016 Google Inc.
+# Copyright 2018 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/optional-kubernetes-engine/config.js
+++ b/optional-kubernetes-engine/config.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/lib/background.js
+++ b/optional-kubernetes-engine/lib/background.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/lib/images.js
+++ b/optional-kubernetes-engine/lib/images.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/lib/logging.js
+++ b/optional-kubernetes-engine/lib/logging.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/lib/oauth2.js
+++ b/optional-kubernetes-engine/lib/oauth2.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/package.json
+++ b/optional-kubernetes-engine/package.json
@@ -1,35 +1,15 @@
 {
   "name": "nodejs-getting-started",
-  "version": "1.0.0",
   "description": "End to end sample for running Node.js applications on Google Cloud Platform",
-  "repository": "https://github.com/GoogleCloudPlatform/nodejs-getting-started",
-  "private": true,
-  "scripts": {
-    "start": "node ${SCRIPT:-app.js}",
-    "test": "repo-tools test app && ava -t 30s --tap test/*.test.js",
-    "e2e": "echo Testing deployment at $TEST_URL; ava -T 60s --tap test/*.test.js",
-    "cover": "nyc --cache npm test; nyc report --reporter=html",
-    "init-cloudsql": "node books/model-cloudsql.js"
-  },
+  "version": "1.0.0",
+  "license": "Apache-2.0",
   "author": "Google Inc.",
-  "contributors": [
-    {
-      "name": "Jon Wayne Parrott",
-      "email": "jonwayne@google.com"
-    },
-    {
-      "name": "Jonathan Simon",
-      "email": "jbsimon@google.com"
-    },
-    {
-      "name": "Jason Dobry",
-      "email": "jdobry@google.com"
-    },
-    {
-      "name": "Ace Nassri",
-      "email": "anassri@google.com"
-    }
-  ],
+  "engines": {
+    "node": ">=8"
+  },
+  "repository": "https://github.com/GoogleCloudPlatform/nodejs-getting-started",
+  "main": "src/index.js",
+  "private": true,
   "cloud-repo-tools": {
     "requiresKeyFile": true,
     "requiresProjectId": true,
@@ -42,7 +22,6 @@
       }
     }
   },
-  "license": "Apache-2.0",
   "semistandard": {
     "globals": [
       "after",
@@ -52,6 +31,31 @@
       "describe",
       "it"
     ]
+  },
+  "contributors": [
+    "Ace Nassri <anassri@google.com>",
+    "Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>",
+    "Allen Day <allenday@users.noreply.github.com>",
+    "André Cipriani Bandarra <andreban@gmail.com>",
+    "Dominik Staskiewicz <stadominik@gmail.com>",
+    "F. Hinkelmann <fhinkel@vt.edu>",
+    "Jason Dobry <jdobry@google.com>",
+    "Jon Wayne Parrott <jonwayne@google.com>",
+    "Justin Beckwith <justin.beckwith@gmail.com>",
+    "Michael McDonald <mcdonald@firebase.com>",
+    "Sean McBreen <seanmcb@google.com>",
+    "Steren <steren.giannini@gmail.com>",
+    "Steve Perry <steveperry-53@users.noreply.github.com>",
+    "chenyumic <chenyumic@google.com>",
+    "renovate[bot] <renovate[bot]@users.noreply.github.com>",
+    "shollyman <shollyman@google.com>"
+  ],
+  "scripts": {
+    "start": "node ${SCRIPT:-app.js}",
+    "test": "repo-tools test app && ava -t 30s --tap test/*.test.js",
+    "e2e": "echo Testing deployment at $TEST_URL; ava -T 60s --tap test/*.test.js",
+    "cover": "nyc --cache npm test; nyc report --reporter=html",
+    "init-cloudsql": "node books/model-cloudsql.js"
   },
   "dependencies": {
     "@google-cloud/datastore": "2.0.0",
@@ -85,8 +89,5 @@
     "proxyquire": "1.8.0",
     "supertest": "^3.3.0",
     "sinon": "^4.5.0"
-  },
-  "engines": {
-    "node": ">=8"
   }
 }

--- a/optional-kubernetes-engine/test/_api-tests.js
+++ b/optional-kubernetes-engine/test/_api-tests.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/test/_crud-tests.js
+++ b/optional-kubernetes-engine/test/_crud-tests.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/test/_test-config.js
+++ b/optional-kubernetes-engine/test/_test-config.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/test/_test-config.worker.js
+++ b/optional-kubernetes-engine/test/_test-config.worker.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/test/app.test.js
+++ b/optional-kubernetes-engine/test/app.test.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/test/background.test.js
+++ b/optional-kubernetes-engine/test/background.test.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/test/cloudsql.test.js
+++ b/optional-kubernetes-engine/test/cloudsql.test.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/test/datastore.test.js
+++ b/optional-kubernetes-engine/test/datastore.test.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/test/mongodb.test.js
+++ b/optional-kubernetes-engine/test/mongodb.test.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/test/oauth2.test.js
+++ b/optional-kubernetes-engine/test/oauth2.test.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/test/worker.test.js
+++ b/optional-kubernetes-engine/test/worker.test.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/optional-kubernetes-engine/views/base.pug
+++ b/optional-kubernetes-engine/views/base.pug
@@ -1,4 +1,4 @@
-//- Copyright 2017, Google, Inc.
+//- Copyright 2018, Google, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/optional-kubernetes-engine/views/books/form.pug
+++ b/optional-kubernetes-engine/views/books/form.pug
@@ -1,4 +1,4 @@
-//- Copyright 2017, Google, Inc.
+//- Copyright 2018, Google, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/optional-kubernetes-engine/views/books/list.pug
+++ b/optional-kubernetes-engine/views/books/list.pug
@@ -1,4 +1,4 @@
-//- Copyright 2017, Google, Inc.
+//- Copyright 2018, Google, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/optional-kubernetes-engine/views/books/view.pug
+++ b/optional-kubernetes-engine/views/books/view.pug
@@ -1,4 +1,4 @@
-//- Copyright 2017, Google, Inc.
+//- Copyright 2018, Google, Inc.
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at

--- a/optional-kubernetes-engine/worker.js
+++ b/optional-kubernetes-engine/worker.js
@@ -1,4 +1,4 @@
-// Copyright 2017, Google, Inc.
+// Copyright 2018, Google, Inc.
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at


### PR DESCRIPTION
The current image has Node 8. Rather than checking for outdated
0.12, we check for 8.

Clean up Copyright years. Update `package.json` generated by `repo-tools`.