### PR TITLE
Fix GCE example

### DIFF
--- a/7-gce/gce/startup-script.sh
+++ b/7-gce/gce/startup-script.sh
@@ -28,11 +28,11 @@ service google-fluentd restart &
 
 # Install dependencies from apt
 apt-get update
-apt-get install -yq ca-certificates git nodejs build-essential supervisor
+apt-get install -yq ca-certificates git build-essential supervisor
 
 # Install nodejs
 mkdir /opt/nodejs
-curl https://nodejs.org/dist/v4.2.2/node-v4.2.2-linux-x64.tar.gz | tar xvzf - -C /opt/nodejs --strip-components=1
+curl https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-x64.tar.gz | tar xvzf - -C /opt/nodejs --strip-components=1
 ln -s /opt/nodejs/bin/node /usr/bin/node
 ln -s /opt/nodejs/bin/npm /usr/bin/npm
 

--- a/7-gce/gce/startup-script.sh
+++ b/7-gce/gce/startup-script.sh
@@ -18,6 +18,7 @@ set -v
 
 # Talk to the metadata server to get the project id
 PROJECTID=$(curl -s "http://metadata.google.internal/computeMetadata/v1/project/project-id" -H "Metadata-Flavor: Google")
+REPOSITORY="[YOUR-REPOSITORY]"
 
 # Install logging monitor. The monitor will automatically pick up logs sent to
 # syslog.
@@ -40,7 +41,7 @@ ln -s /opt/nodejs/bin/npm /usr/bin/npm
 # git requires $HOME and it's not set during the startup script.
 export HOME=/root
 git config --global credential.helper gcloud.sh
-git clone https://source.developers.google.com/p/$PROJECTID /opt/app
+git clone https://source.developers.google.com/p/${PROJECTID}/r/${REPOSITORY} /opt/app
 
 # Install app dependencies
 cd /opt/app/7-gce


### PR DESCRIPTION
Update Node version and fix `git clone` link.

Fixes some of the issues in https://github.com/GoogleCloudPlatform/nodejs-getting-started/issues/169