### PR TITLE
GCLOUD_PROJECT -> GOOGLE_CLOUD_PROJECT

### DIFF
--- a/.kokoro/e2e-tests/build.sh
+++ b/.kokoro/e2e-tests/build.sh
@@ -54,10 +54,10 @@ function cleanup {
 trap cleanup EXIT
 
 # Configure gcloud
-export GCLOUD_PROJECT=nodejs-getting-started-tests
+export GOOGLE_CLOUD_PROJECT=nodejs-getting-started-tests
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
-gcloud config set project $GCLOUD_PROJECT
+gcloud config set project $GOOGLE_CLOUD_PROJECT
 
 # Install Node dependencies
 yarn global add @google-cloud/nodejs-repo-tools

--- a/.kokoro/e2e-tests/container/build.sh
+++ b/.kokoro/e2e-tests/container/build.sh
@@ -56,16 +56,16 @@ trap cleanup EXIT
 set -e;
 
 # Configure gcloud
-export GCLOUD_PROJECT=nodejs-getting-started-tests
+export GOOGLE_CLOUD_PROJECT=nodejs-getting-started-tests
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
-gcloud config set project $GCLOUD_PROJECT
+gcloud config set project $GOOGLE_CLOUD_PROJECT
 
 # Extract secrets
 export MYSQL_USER=$(cat ${KOKORO_GFILE_DIR}/secrets-mysql-user.json)
 export MYSQL_PASSWORD=$(cat ${KOKORO_GFILE_DIR}/secrets-mysql-password.json)
 export MONGO_URL=$(cat ${KOKORO_GFILE_DIR}/secrets-mongo-url.json)
-export INSTANCE_CONNECTION_NAME="${GCLOUD_PROJECT}:us-central1:integration-test-instance"
+export INSTANCE_CONNECTION_NAME="${GOOGLE_CLOUD_PROJECT}:us-central1:integration-test-instance"
 
 
 # Load the Node version manager
@@ -87,12 +87,12 @@ cp $GOOGLE_APPLICATION_CREDENTIALS key.json
 yarn install
 
 # Build and deploy Docker images
-docker build -t gcr.io/${GCLOUD_PROJECT}/bookshelf .
-gcloud docker -- push gcr.io/${GCLOUD_PROJECT}/bookshelf
+docker build -t gcr.io/${GOOGLE_CLOUD_PROJECT}/bookshelf .
+gcloud docker -- push gcr.io/${GOOGLE_CLOUD_PROJECT}/bookshelf
 
 # Substitute required variables
 # Use sed, as @google-cloud/nodejs-repo-tools doesn't support K8s deployments
-sed -i.bak "s/\[GCLOUD_PROJECT\]/${GCLOUD_PROJECT}/g" bookshelf-*.yaml
+sed -i.bak "s/\[GOOGLE_CLOUD_PROJECT\]/${GOOGLE_CLOUD_PROJECT}/g" bookshelf-*.yaml
 sed -i.bak "s/\[INSTANCE_CONNECTION_NAME\]/${INSTANCE_CONNECTION_NAME}/g" bookshelf-*.yaml
 
 # Create and connect to the required K8s cluster

--- a/.kokoro/presubmit/cloudsql.sh
+++ b/.kokoro/presubmit/cloudsql.sh
@@ -29,10 +29,10 @@ export NODE_ENV=development
 export DATA_BACKEND="cloudsql"
 
 # Configure gcloud
-export GCLOUD_PROJECT=nodejs-getting-started-tests
+export GOOGLE_CLOUD_PROJECT=nodejs-getting-started-tests
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
-gcloud config set project $GCLOUD_PROJECT
+gcloud config set project $GOOGLE_CLOUD_PROJECT
 
 # Load the Node version manager
 export NVM_DIR="$HOME/.nvm"
@@ -50,7 +50,7 @@ find . -name package.json -maxdepth 2 -execdir sh -c "cp ${KOKORO_GFILE_DIR}/sec
 find . -name package.json -maxdepth 2 -execdir sh -c "cp $GOOGLE_APPLICATION_CREDENTIALS key.json" \;
 
 # Start SQL proxy
-cloud_sql_proxy -instances="${GCLOUD_PROJECT}:us-central1:integration-test-instance"=tcp:3306 &
+cloud_sql_proxy -instances="${GOOGLE_CLOUD_PROJECT}:us-central1:integration-test-instance"=tcp:3306 &
 
 # Install dependencies (for running the tests, not the apps themselves)
 npm install

--- a/.kokoro/presubmit/datastore.sh
+++ b/.kokoro/presubmit/datastore.sh
@@ -29,10 +29,10 @@ export NODE_ENV=development
 export DATA_BACKEND="datastore"
 
 # Configure gcloud
-export GCLOUD_PROJECT=nodejs-getting-started-tests
+export GOOGLE_CLOUD_PROJECT=nodejs-getting-started-tests
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
-gcloud config set project $GCLOUD_PROJECT
+gcloud config set project $GOOGLE_CLOUD_PROJECT
 
 # Load the Node version manager
 export NVM_DIR="$HOME/.nvm"

--- a/.kokoro/presubmit/mongodb.sh
+++ b/.kokoro/presubmit/mongodb.sh
@@ -26,10 +26,10 @@ export NODE_ENV=development
 export DATA_BACKEND="mongodb"
 
 # Configure gcloud
-export GCLOUD_PROJECT=nodejs-getting-started-tests
+export GOOGLE_CLOUD_PROJECT=nodejs-getting-started-tests
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
-gcloud config set project $GCLOUD_PROJECT
+gcloud config set project $GOOGLE_CLOUD_PROJECT
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm

--- a/2-structured-data/books/model-datastore.js
+++ b/2-structured-data/books/model-datastore.js
@@ -18,7 +18,7 @@ const config = require('../config');
 
 // [START config]
 const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const kind = 'Book';
 // [END config]

--- a/2-structured-data/config.js
+++ b/2-structured-data/config.js
@@ -24,7 +24,7 @@ nconf
   // 2. Environment variables
   .env([
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
+    'GOOGLE_CLOUD_PROJECT',
     'INSTANCE_CONNECTION_NAME',
     'MYSQL_USER',
     'MYSQL_PASSWORD',
@@ -42,7 +42,7 @@ nconf
     DATA_BACKEND: 'datastore',
 
     // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
+    GOOGLE_CLOUD_PROJECT: '',
 
     MYSQL_USER: '',
     MYSQL_PASSWORD: '',
@@ -51,7 +51,7 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
+checkConfig('GOOGLE_CLOUD_PROJECT');
 
 if (nconf.get('DATA_BACKEND') === 'cloudsql') {
   checkConfig('MYSQL_USER');

--- a/2-structured-data/test/_test-config.js
+++ b/2-structured-data/test/_test-config.js
@@ -28,6 +28,6 @@ module.exports = {
   },
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
+  project: process.env.GOOGLE_CLOUD_PROJECT,
   msg: `Bookshelf`,
 };

--- a/2-structured-data/test/app.test.js
+++ b/2-structured-data/test/app.test.js
@@ -51,8 +51,8 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
+  t.throws(testFunc, Error, getMsg(`GOOGLE_CLOUD_PROJECT`));
+  nconfMock.GOOGLE_CLOUD_PROJECT = `project`;
 
   t.notThrows(testFunc);
 

--- a/3-binary-data/books/model-datastore.js
+++ b/3-binary-data/books/model-datastore.js
@@ -17,7 +17,7 @@ const Datastore = require('@google-cloud/datastore');
 const config = require('../config');
 
 const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const kind = 'Book';
 

--- a/3-binary-data/config.js
+++ b/3-binary-data/config.js
@@ -25,7 +25,7 @@ nconf
   .env([
     'CLOUD_BUCKET',
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
+    'GOOGLE_CLOUD_PROJECT',
     'INSTANCE_CONNECTION_NAME',
     'MYSQL_USER',
     'MYSQL_PASSWORD',
@@ -46,7 +46,7 @@ nconf
     DATA_BACKEND: 'datastore',
 
     // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
+    GOOGLE_CLOUD_PROJECT: '',
 
     MYSQL_USER: '',
     MYSQL_PASSWORD: '',
@@ -55,7 +55,7 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
+checkConfig('GOOGLE_CLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 
 if (nconf.get('DATA_BACKEND') === 'cloudsql') {

--- a/3-binary-data/lib/images.js
+++ b/3-binary-data/lib/images.js
@@ -19,7 +19,7 @@ const config = require('../config');
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
 const storage = Storage({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const bucket = storage.bucket(CLOUD_BUCKET);
 

--- a/3-binary-data/test/_test-config.js
+++ b/3-binary-data/test/_test-config.js
@@ -28,6 +28,6 @@ module.exports = {
   },
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
+  project: process.env.GOOGLE_CLOUD_PROJECT,
   msg: `Bookshelf`,
 };

--- a/3-binary-data/test/app.test.js
+++ b/3-binary-data/test/app.test.js
@@ -51,8 +51,8 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
+  t.throws(testFunc, Error, getMsg(`GOOGLE_CLOUD_PROJECT`));
+  nconfMock.GOOGLE_CLOUD_PROJECT = `project`;
 
   t.throws(testFunc, Error, getMsg(`CLOUD_BUCKET`));
   nconfMock.CLOUD_BUCKET = `bucket`;

--- a/4-auth/books/model-datastore.js
+++ b/4-auth/books/model-datastore.js
@@ -17,7 +17,7 @@ const Datastore = require('@google-cloud/datastore');
 const config = require('../config');
 
 const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const kind = 'Book';
 

--- a/4-auth/config.js
+++ b/4-auth/config.js
@@ -25,7 +25,7 @@ nconf
   .env([
     'CLOUD_BUCKET',
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
+    'GOOGLE_CLOUD_PROJECT',
     'MEMCACHE_URL',
     'MEMCACHE_USERNAME',
     'MEMCACHE_PASSWORD',
@@ -53,7 +53,7 @@ nconf
     DATA_BACKEND: 'datastore',
 
     // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
+    GOOGLE_CLOUD_PROJECT: '',
 
     MYSQL_USER: '',
     MYSQL_PASSWORD: '',
@@ -69,7 +69,7 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
+checkConfig('GOOGLE_CLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 checkConfig('OAUTH2_CLIENT_ID');
 checkConfig('OAUTH2_CLIENT_SECRET');

--- a/4-auth/lib/images.js
+++ b/4-auth/lib/images.js
@@ -19,7 +19,7 @@ const config = require('../config');
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
 const storage = Storage({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const bucket = storage.bucket(CLOUD_BUCKET);
 

--- a/4-auth/test/_test-config.js
+++ b/4-auth/test/_test-config.js
@@ -28,6 +28,6 @@ module.exports = {
   },
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
+  project: process.env.GOOGLE_CLOUD_PROJECT,
   msg: `Bookshelf`,
 };

--- a/4-auth/test/app.test.js
+++ b/4-auth/test/app.test.js
@@ -51,8 +51,8 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
+  t.throws(testFunc, Error, getMsg(`GOOGLE_CLOUD_PROJECT`));
+  nconfMock.GOOGLE_CLOUD_PROJECT = `project`;
 
   t.throws(testFunc, Error, getMsg(`CLOUD_BUCKET`));
   nconfMock.CLOUD_BUCKET = `bucket`;

--- a/5-logging/books/model-datastore.js
+++ b/5-logging/books/model-datastore.js
@@ -17,7 +17,7 @@ const Datastore = require('@google-cloud/datastore');
 const config = require('../config');
 
 const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const kind = 'Book';
 

--- a/5-logging/config.js
+++ b/5-logging/config.js
@@ -25,7 +25,7 @@ nconf
   .env([
     'CLOUD_BUCKET',
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
+    'GOOGLE_CLOUD_PROJECT',
     'MEMCACHE_URL',
     'MEMCACHE_USERNAME',
     'MEMCACHE_PASSWORD',
@@ -53,7 +53,7 @@ nconf
     DATA_BACKEND: 'datastore',
 
     // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
+    GOOGLE_CLOUD_PROJECT: '',
 
     MYSQL_USER: '',
     MYSQL_PASSWORD: '',
@@ -69,7 +69,7 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
+checkConfig('GOOGLE_CLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 checkConfig('OAUTH2_CLIENT_ID');
 checkConfig('OAUTH2_CLIENT_SECRET');

--- a/5-logging/lib/images.js
+++ b/5-logging/lib/images.js
@@ -19,7 +19,7 @@ const config = require('../config');
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
 const storage = Storage({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const bucket = storage.bucket(CLOUD_BUCKET);
 

--- a/5-logging/test/_test-config.js
+++ b/5-logging/test/_test-config.js
@@ -28,6 +28,6 @@ module.exports = {
   },
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
+  project: process.env.GOOGLE_CLOUD_PROJECT,
   msg: `Bookshelf`,
 };

--- a/5-logging/test/app.test.js
+++ b/5-logging/test/app.test.js
@@ -51,8 +51,8 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
+  t.throws(testFunc, Error, getMsg(`GOOGLE_CLOUD_PROJECT`));
+  nconfMock.GOOGLE_CLOUD_PROJECT = `project`;
 
   t.throws(testFunc, Error, getMsg(`CLOUD_BUCKET`));
   nconfMock.CLOUD_BUCKET = `bucket`;

--- a/6-pubsub/books/model-datastore.js
+++ b/6-pubsub/books/model-datastore.js
@@ -18,7 +18,7 @@ const config = require('../config');
 const background = require('../lib/background');
 
 const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const kind = 'Book';
 

--- a/6-pubsub/config.js
+++ b/6-pubsub/config.js
@@ -25,7 +25,7 @@ nconf
   .env([
     'CLOUD_BUCKET',
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
+    'GOOGLE_CLOUD_PROJECT',
     'MEMCACHE_URL',
     'MEMCACHE_USERNAME',
     'MEMCACHE_PASSWORD',
@@ -54,7 +54,7 @@ nconf
     DATA_BACKEND: 'datastore',
 
     // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
+    GOOGLE_CLOUD_PROJECT: '',
 
     // Connection url for the Memcache instance used to store session data
     MEMCACHE_URL: 'localhost:11211',
@@ -75,7 +75,7 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
+checkConfig('GOOGLE_CLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 checkConfig('OAUTH2_CLIENT_ID');
 checkConfig('OAUTH2_CLIENT_SECRET');

--- a/6-pubsub/lib/background.js
+++ b/6-pubsub/lib/background.js
@@ -20,7 +20,7 @@ const logging = require('./logging');
 const topicName = config.get('TOPIC_NAME');
 
 const pubsub = new Pubsub({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 
 // This configuration will automatically create the topic if

--- a/6-pubsub/lib/images.js
+++ b/6-pubsub/lib/images.js
@@ -21,7 +21,7 @@ const logging = require('./logging');
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
 const storage = Storage({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const bucket = storage.bucket(CLOUD_BUCKET);
 

--- a/6-pubsub/test/_test-config.js
+++ b/6-pubsub/test/_test-config.js
@@ -26,7 +26,7 @@ module.exports = {
   port: PORT,
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
+  project: process.env.GOOGLE_CLOUD_PROJECT,
   env: {
     PORT: PORT,
     TOPIC_NAME: `book-process-queue-${TESTNAME}`,

--- a/6-pubsub/test/_test-config.worker.js
+++ b/6-pubsub/test/_test-config.worker.js
@@ -14,7 +14,7 @@
 'use strict';
 
 const path = require(`path`);
-const PROJECT_ID = process.env.GCLOUD_PROJECT;
+const PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT;
 const TESTNAME = `6-pubsub`;
 const PORT = 8091;
 const VERSION = `${process.env.GAE_VERSION || TESTNAME}`;

--- a/6-pubsub/test/app.test.js
+++ b/6-pubsub/test/app.test.js
@@ -51,8 +51,8 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
+  t.throws(testFunc, Error, getMsg(`GOOGLE_CLOUD_PROJECT`));
+  nconfMock.GOOGLE_CLOUD_PROJECT = `project`;
 
   t.throws(testFunc, Error, getMsg(`CLOUD_BUCKET`));
   nconfMock.CLOUD_BUCKET = `bucket`;

--- a/6-pubsub/test/background.test.js
+++ b/6-pubsub/test/background.test.js
@@ -23,7 +23,7 @@ const mocks = {};
 test.beforeEach(t => {
   // Mock dependencies used by background.js
   mocks.config = {
-    GCLOUD_PROJECT: process.env.GCLOUD_PROJECT,
+    GOOGLE_CLOUD_PROJECT: process.env.GOOGLE_CLOUD_PROJECT,
     SUBSCRIPTION_NAME: `shared-worker-subscription`,
     TOPIC_NAME: `book-process-queue`,
   };

--- a/7-gce/README.md
+++ b/7-gce/README.md
@@ -43,7 +43,7 @@ and deploying this sample.
 
         cp config-default.json config.json
 
-    * Set `GCLOUD_PROJECT` in `config.json` to your Google Cloud Platform
+    * Set `GOOGLE_CLOUD_PROJECT` in `config.json` to your Google Cloud Platform
       project ID.
     * Set `DATA_BACKEND` in `config.json` to one of `"datastore"`, `"cloudsql"`,
       or `"mongodb"`.

--- a/7-gce/books/model-datastore.js
+++ b/7-gce/books/model-datastore.js
@@ -18,7 +18,7 @@ const config = require('../config');
 const background = require('../lib/background');
 
 const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const kind = 'Book';
 

--- a/7-gce/config.js
+++ b/7-gce/config.js
@@ -25,7 +25,7 @@ nconf
   .env([
     'CLOUD_BUCKET',
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
+    'GOOGLE_CLOUD_PROJECT',
     'MEMCACHE_URL',
     'MONGO_URL',
     'MONGO_COLLECTION',
@@ -56,7 +56,7 @@ nconf
     DATA_BACKEND: 'datastore',
 
     // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
+    GOOGLE_CLOUD_PROJECT: '',
 
     // Connection url for the Memcache instance used to store session data
     MEMCACHE_URL: 'localhost:11211',
@@ -83,7 +83,7 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
+checkConfig('GOOGLE_CLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 checkConfig('OAUTH2_CLIENT_ID');
 checkConfig('OAUTH2_CLIENT_SECRET');

--- a/7-gce/lib/background.js
+++ b/7-gce/lib/background.js
@@ -21,7 +21,7 @@ const topicName = config.get('TOPIC_NAME');
 const subscriptionName = config.get('SUBSCRIPTION_NAME');
 
 const pubsub = new Pubsub({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 
 // This configuration will automatically create the topic if

--- a/7-gce/lib/images.js
+++ b/7-gce/lib/images.js
@@ -21,7 +21,7 @@ const logging = require('./logging');
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
 const storage = Storage({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const bucket = storage.bucket(CLOUD_BUCKET);
 

--- a/7-gce/test/_test-config.js
+++ b/7-gce/test/_test-config.js
@@ -26,7 +26,7 @@ module.exports = {
   port: PORT,
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
+  project: process.env.GOOGLE_CLOUD_PROJECT,
   env: {
     PORT: PORT,
     SUBSCRIPTION_NAME: `shared-worker-subscription-${TESTNAME}`,

--- a/7-gce/test/_test-config.worker.js
+++ b/7-gce/test/_test-config.worker.js
@@ -14,7 +14,7 @@
 'use strict';
 
 const path = require(`path`);
-const PROJECT_ID = process.env.GCLOUD_PROJECT;
+const PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT;
 const TESTNAME = `7-gce`;
 const PORT = 8092;
 const VERSION = `${process.env.GAE_VERSION || TESTNAME}`;

--- a/7-gce/test/app.test.js
+++ b/7-gce/test/app.test.js
@@ -51,8 +51,8 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
+  t.throws(testFunc, Error, getMsg(`GOOGLE_CLOUD_PROJECT`));
+  nconfMock.GOOGLE_CLOUD_PROJECT = `project`;
 
   t.throws(testFunc, Error, getMsg(`CLOUD_BUCKET`));
   nconfMock.CLOUD_BUCKET = `bucket`;

--- a/7-gce/test/background.test.js
+++ b/7-gce/test/background.test.js
@@ -23,7 +23,7 @@ const mocks = {};
 test.beforeEach(t => {
   // Mock dependencies used by background.js
   mocks.config = {
-    GCLOUD_PROJECT: process.env.GCLOUD_PROJECT,
+    GOOGLE_CLOUD_PROJECT: process.env.GOOGLE_CLOUD_PROJECT,
     SUBSCRIPTION_NAME: `shared-worker-subscription`,
     TOPIC_NAME: `book-process-queue`,
   };

--- a/optional-kubernetes-engine/Makefile
+++ b/optional-kubernetes-engine/Makefile
@@ -1,4 +1,4 @@
-GCLOUD_PROJECT:=$(shell gcloud config list project --format="value(core.project)")
+GOOGLE_CLOUD_PROJECT:=$(shell gcloud config list project --format="value(core.project)")
 
 .PHONY: all
 all: deploy
@@ -13,20 +13,20 @@ create-cluster:
 
 .PHONY: create-bucket
 create-bucket:
-	gsutil mb gs://$(GCLOUD_PROJECT)
-    gsutil defacl set public-read gs://$(GCLOUD_PROJECT)
+	gsutil mb gs://$(GOOGLE_CLOUD_PROJECT)
+    gsutil defacl set public-read gs://$(GOOGLE_CLOUD_PROJECT)
 
 .PHONY: build
 build:
-	docker build -t gcr.io/$(GCLOUD_PROJECT)/bookshelf .
+	docker build -t gcr.io/$(GOOGLE_CLOUD_PROJECT)/bookshelf .
 
 .PHONY: push
 push: build
-	gcloud docker push gcr.io/$(GCLOUD_PROJECT)/bookshelf
+	gcloud docker push gcr.io/$(GOOGLE_CLOUD_PROJECT)/bookshelf
 
 .PHONY: template
 template:
-	sed -i ".tmpl" "s/\[GCLOUD_PROJECT\]/$(GCLOUD_PROJECT)/g" bookshelf-*.yaml
+	sed -i ".tmpl" "s/\[GOOGLE_CLOUD_PROJECT\]/$(GOOGLE_CLOUD_PROJECT)/g" bookshelf-*.yaml
 
 .PHONY: create-service
 create-service:

--- a/optional-kubernetes-engine/books/model-datastore.js
+++ b/optional-kubernetes-engine/books/model-datastore.js
@@ -18,7 +18,7 @@ const config = require('../config');
 const background = require('../lib/background');
 
 const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const kind = 'Book';
 

--- a/optional-kubernetes-engine/bookshelf-frontend-cloudsql.yaml
+++ b/optional-kubernetes-engine/bookshelf-frontend-cloudsql.yaml
@@ -35,8 +35,8 @@ spec:
     spec:
       containers:
       - name: bookshelf-app
-        # Replace [GCLOUD_PROJECT] with your project ID or use `make template`.
-        image: gcr.io/[GCLOUD_PROJECT]/bookshelf
+        # Replace [GOOGLE_CLOUD_PROJECT] with your project ID or use `make template`.
+        image: gcr.io/[GOOGLE_CLOUD_PROJECT]/bookshelf
         # This setting makes nodes pull the docker image every time before
         # starting the pod. This is useful when debugging, but should be turned
         # off in production.
@@ -49,7 +49,7 @@ spec:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /var/run/secret/cloud.google.com/secrets-key.json
           - name: PROJECT_ID
-            value: [GCLOUD_PROJECT]
+            value: [GOOGLE_CLOUD_PROJECT]
           - name: MYSQL_USER
             valueFrom:
               secretKeyRef:

--- a/optional-kubernetes-engine/bookshelf-frontend-datastore.yaml
+++ b/optional-kubernetes-engine/bookshelf-frontend-datastore.yaml
@@ -35,8 +35,8 @@ spec:
     spec:
       containers:
       - name: bookshelf-app
-        # Replace [GCLOUD_PROJECT] with your project ID or use `make template`.
-        image: gcr.io/[GCLOUD_PROJECT]/bookshelf
+        # Replace [GOOGLE_CLOUD_PROJECT] with your project ID or use `make template`.
+        image: gcr.io/[GOOGLE_CLOUD_PROJECT]/bookshelf
         # This setting makes nodes pull the docker image every time before
         # starting the pod. This is useful when debugging, but should be turned
         # off in production.
@@ -47,4 +47,4 @@ spec:
           containerPort: 8080
         env:
           - name: PROJECT_ID
-            value: [GCLOUD_PROJECT]
+            value: [GOOGLE_CLOUD_PROJECT]

--- a/optional-kubernetes-engine/bookshelf-frontend-mongodb.yaml
+++ b/optional-kubernetes-engine/bookshelf-frontend-mongodb.yaml
@@ -35,8 +35,8 @@ spec:
     spec:
       containers:
       - name: bookshelf-app
-        # Replace [GCLOUD_PROJECT] with your project ID or use `make template`.
-        image: gcr.io/[GCLOUD_PROJECT]/bookshelf
+        # Replace [GOOGLE_CLOUD_PROJECT] with your project ID or use `make template`.
+        image: gcr.io/[GOOGLE_CLOUD_PROJECT]/bookshelf
         # This setting makes nodes pull the docker image every time before
         # starting the pod. This is useful when debugging, but should be turned
         # off in production.
@@ -47,7 +47,7 @@ spec:
           containerPort: 8080
         env:
           - name: PROJECT_ID
-            value: [GCLOUD_PROJECT]
+            value: [GOOGLE_CLOUD_PROJECT]
           - name: MONGO_URL
             valueFrom:
               secretKeyRef:

--- a/optional-kubernetes-engine/bookshelf-worker-cloudsql.yaml
+++ b/optional-kubernetes-engine/bookshelf-worker-cloudsql.yaml
@@ -35,8 +35,8 @@ spec:
     spec:
       containers:
       - name: bookshelf-app
-        # Replace [GCLOUD_PROJECT] with your project ID or use `make template`.
-        image: gcr.io/[GCLOUD_PROJECT]/bookshelf
+        # Replace [GOOGLE_CLOUD_PROJECT] with your project ID or use `make template`.
+        image: gcr.io/[GOOGLE_CLOUD_PROJECT]/bookshelf
         # This setting makes nodes pull the docker image every time before
         # starting the pod. This is useful when debugging, but should be turned
         # off in production.
@@ -50,7 +50,7 @@ spec:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/run/secret/cloud.google.com/secrets-key.json
         - name: PROJECT_ID
-          value: [GCLOUD_PROJECT]
+          value: [GOOGLE_CLOUD_PROJECT]
         - name: MYSQL_USER
           valueFrom:
             secretKeyRef:

--- a/optional-kubernetes-engine/bookshelf-worker-datastore.yaml
+++ b/optional-kubernetes-engine/bookshelf-worker-datastore.yaml
@@ -35,8 +35,8 @@ spec:
     spec:
       containers:
       - name: bookshelf-app
-        # Replace [GCLOUD_PROJECT] with your project ID or use `make template`.
-        image: gcr.io/[GCLOUD_PROJECT]/bookshelf
+        # Replace [GOOGLE_CLOUD_PROJECT] with your project ID or use `make template`.
+        image: gcr.io/[GOOGLE_CLOUD_PROJECT]/bookshelf
         # This setting makes nodes pull the docker image every time before
         # starting the pod. This is useful when debugging, but should be turned
         # off in production.
@@ -48,4 +48,4 @@ spec:
         - name: SCRIPT
           value: worker.js
         - name: PROJECT_ID
-          value: [GCLOUD_PROJECT]
+          value: [GOOGLE_CLOUD_PROJECT]

--- a/optional-kubernetes-engine/bookshelf-worker-mongodb.yaml
+++ b/optional-kubernetes-engine/bookshelf-worker-mongodb.yaml
@@ -35,8 +35,8 @@ spec:
     spec:
       containers:
       - name: bookshelf-app
-        # Replace [GCLOUD_PROJECT] with your project ID or use `make template`.
-        image: gcr.io/[GCLOUD_PROJECT]/bookshelf
+        # Replace [GOOGLE_CLOUD_PROJECT] with your project ID or use `make template`.
+        image: gcr.io/[GOOGLE_CLOUD_PROJECT]/bookshelf
         # This setting makes nodes pull the docker image every time before
         # starting the pod. This is useful when debugging, but should be turned
         # off in production.
@@ -48,7 +48,7 @@ spec:
         - name: SCRIPT
           value: worker.js
         - name: PROJECT_ID
-          value: [GCLOUD_PROJECT]
+          value: [GOOGLE_CLOUD_PROJECT]
         - name: MONGO_URL
           valueFrom:
               secretKeyRef:

--- a/optional-kubernetes-engine/config.js
+++ b/optional-kubernetes-engine/config.js
@@ -25,7 +25,7 @@ nconf
   .env([
     'CLOUD_BUCKET',
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
+    'GOOGLE_CLOUD_PROJECT',
     'MEMCACHE_URL',
     'MONGO_URL',
     'MONGO_COLLECTION',
@@ -56,7 +56,7 @@ nconf
     DATA_BACKEND: 'datastore',
 
     // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
+    GOOGLE_CLOUD_PROJECT: '',
 
     // Connection url for the Memcache instance used to store session data
     MEMCACHE_URL: 'localhost:11211',
@@ -83,7 +83,7 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
+checkConfig('GOOGLE_CLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 checkConfig('OAUTH2_CLIENT_ID');
 checkConfig('OAUTH2_CLIENT_SECRET');

--- a/optional-kubernetes-engine/lib/background.js
+++ b/optional-kubernetes-engine/lib/background.js
@@ -21,7 +21,7 @@ const topicName = config.get('TOPIC_NAME');
 const subscriptionName = config.get('SUBSCRIPTION_NAME');
 
 const pubsub = new Pubsub({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 
 // This configuration will automatically create the topic if

--- a/optional-kubernetes-engine/lib/images.js
+++ b/optional-kubernetes-engine/lib/images.js
@@ -21,7 +21,7 @@ const logging = require('./logging');
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
 const storage = Storage({
-  projectId: config.get('GCLOUD_PROJECT'),
+  projectId: config.get('GOOGLE_CLOUD_PROJECT'),
 });
 const bucket = storage.bucket(CLOUD_BUCKET);
 

--- a/optional-kubernetes-engine/test/_test-config.js
+++ b/optional-kubernetes-engine/test/_test-config.js
@@ -26,7 +26,7 @@ module.exports = {
   port: PORT,
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
+  project: process.env.GOOGLE_CLOUD_PROJECT,
   env: {
     PORT: PORT,
     SUBSCRIPTION_NAME: `shared-worker-subscription-${TESTNAME}`,

--- a/optional-kubernetes-engine/test/app.test.js
+++ b/optional-kubernetes-engine/test/app.test.js
@@ -51,8 +51,8 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
+  t.throws(testFunc, Error, getMsg(`GOOGLE_CLOUD_PROJECT`));
+  nconfMock.GOOGLE_CLOUD_PROJECT = `project`;
 
   t.throws(testFunc, Error, getMsg(`CLOUD_BUCKET`));
   nconfMock.CLOUD_BUCKET = `bucket`;

--- a/optional-kubernetes-engine/test/background.test.js
+++ b/optional-kubernetes-engine/test/background.test.js
@@ -23,7 +23,7 @@ const mocks = {};
 test.beforeEach(t => {
   // Mock dependencies used by background.js
   mocks.config = {
-    GCLOUD_PROJECT: process.env.GCLOUD_PROJECT,
+    GOOGLE_CLOUD_PROJECT: process.env.GOOGLE_CLOUD_PROJECT,
     SUBSCRIPTION_NAME: `shared-worker-subscription`,
     TOPIC_NAME: `book-process-queue`,
   };


### PR DESCRIPTION
We [prefer](https://cloud.google.com/functions/docs/env-var#reserved_keys_key_validation) `GOOGLE_CLOUD_PROJECT` over `GCLOUD_PROJECT`. Rename a such.

See various docs and comment threads about this:
- https://cloud.google.com/appengine/docs/flexible/nodejs/runtime#environment_variables
- https://github.com/googleapis/nodejs-common/issues/20#issuecomment-360209232
- https://github.com/googleapis/google-cloud-php/issues/827