### PR TITLE
Delete GLOUD_PROJECT variable

### DIFF
--- a/.kokoro/e2e-tests/build.sh
+++ b/.kokoro/e2e-tests/build.sh
@@ -57,7 +57,7 @@ trap cleanup EXIT
 export GCLOUD_PROJECT=nodejs-getting-started-tests
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
-gcloud config set project $GCLOUD_PROJECT
+gcloud config set project ${GCLOUD_PROJECT}
 
 # Install Node dependencies
 yarn global add @google-cloud/nodejs-repo-tools

--- a/.kokoro/e2e-tests/container/build.sh
+++ b/.kokoro/e2e-tests/container/build.sh
@@ -76,7 +76,7 @@ export NVM_DIR="$HOME/.nvm"
 nvm install 8
 
 # Install Node dependencies
-yarn global add @google-cloud/nodejs-repo-tools
+npm install -g @google-cloud/nodejs-repo-tools
 cd github/nodejs-getting-started/${BOOKSHELF_DIRECTORY}
 
 # Copy secrets
@@ -84,7 +84,7 @@ cp ${KOKORO_GFILE_DIR}/secrets-config.json config.json
 cp $GOOGLE_APPLICATION_CREDENTIALS key.json
 
 # Install dependencies (for running the tests, not the apps themselves)
-yarn install
+npm install
 
 # Build and deploy Docker images
 docker build -t gcr.io/${GCLOUD_PROJECT}/bookshelf .

--- a/.kokoro/presubmit/cloudsql.sh
+++ b/.kokoro/presubmit/cloudsql.sh
@@ -29,7 +29,7 @@ export NODE_ENV=development
 export DATA_BACKEND="cloudsql"
 
 # Configure gcloud
-export GCLOUD_PROJECT=nodejs-getting-started-tests
+GCLOUD_PROJECT=nodejs-getting-started-tests
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
 gcloud config set project $GCLOUD_PROJECT

--- a/.kokoro/presubmit/datastore.sh
+++ b/.kokoro/presubmit/datastore.sh
@@ -29,7 +29,7 @@ export NODE_ENV=development
 export DATA_BACKEND="datastore"
 
 # Configure gcloud
-export GCLOUD_PROJECT=nodejs-getting-started-tests
+GCLOUD_PROJECT=nodejs-getting-started-tests
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
 gcloud config set project $GCLOUD_PROJECT

--- a/.kokoro/presubmit/mongodb.sh
+++ b/.kokoro/presubmit/mongodb.sh
@@ -26,7 +26,7 @@ export NODE_ENV=development
 export DATA_BACKEND="mongodb"
 
 # Configure gcloud
-export GCLOUD_PROJECT=nodejs-getting-started-tests
+GCLOUD_PROJECT=nodejs-getting-started-tests
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
 gcloud config set project $GCLOUD_PROJECT

--- a/2-structured-data/books/model-datastore.js
+++ b/2-structured-data/books/model-datastore.js
@@ -14,12 +14,9 @@
 'use strict';
 
 const Datastore = require('@google-cloud/datastore');
-const config = require('../config');
 
 // [START config]
-const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const ds = Datastore();
 const kind = 'Book';
 // [END config]
 

--- a/2-structured-data/config.js
+++ b/2-structured-data/config.js
@@ -24,7 +24,6 @@ nconf
   // 2. Environment variables
   .env([
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
     'INSTANCE_CONNECTION_NAME',
     'MYSQL_USER',
     'MYSQL_PASSWORD',
@@ -41,17 +40,11 @@ nconf
     // configuration.
     DATA_BACKEND: 'datastore',
 
-    // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
-
     MYSQL_USER: '',
     MYSQL_PASSWORD: '',
 
     PORT: 8080,
   });
-
-// Check for required settings
-checkConfig('GCLOUD_PROJECT');
 
 if (nconf.get('DATA_BACKEND') === 'cloudsql') {
   checkConfig('MYSQL_USER');

--- a/2-structured-data/test/_test-config.js
+++ b/2-structured-data/test/_test-config.js
@@ -28,6 +28,5 @@ module.exports = {
   },
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
   msg: `Bookshelf`,
 };

--- a/2-structured-data/test/app.test.js
+++ b/2-structured-data/test/app.test.js
@@ -51,9 +51,6 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
-
   t.notThrows(testFunc);
 
   nconfMock.DATA_BACKEND = `cloudsql`;

--- a/3-binary-data/books/model-datastore.js
+++ b/3-binary-data/books/model-datastore.js
@@ -14,11 +14,8 @@
 'use strict';
 
 const Datastore = require('@google-cloud/datastore');
-const config = require('../config');
 
-const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const ds = Datastore();
 const kind = 'Book';
 
 // Translates from Datastore's entity format to

--- a/3-binary-data/config.js
+++ b/3-binary-data/config.js
@@ -25,7 +25,6 @@ nconf
   .env([
     'CLOUD_BUCKET',
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
     'INSTANCE_CONNECTION_NAME',
     'MYSQL_USER',
     'MYSQL_PASSWORD',
@@ -45,9 +44,6 @@ nconf
     // configuration.
     DATA_BACKEND: 'datastore',
 
-    // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
-
     MYSQL_USER: '',
     MYSQL_PASSWORD: '',
 
@@ -55,7 +51,6 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 
 if (nconf.get('DATA_BACKEND') === 'cloudsql') {

--- a/3-binary-data/lib/images.js
+++ b/3-binary-data/lib/images.js
@@ -18,9 +18,7 @@ const config = require('../config');
 
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
-const storage = Storage({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const storage = Storage();
 const bucket = storage.bucket(CLOUD_BUCKET);
 
 // Returns the public, anonymously accessable URL to a given Cloud Storage

--- a/3-binary-data/test/_test-config.js
+++ b/3-binary-data/test/_test-config.js
@@ -28,6 +28,5 @@ module.exports = {
   },
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
   msg: `Bookshelf`,
 };

--- a/3-binary-data/test/app.test.js
+++ b/3-binary-data/test/app.test.js
@@ -51,9 +51,6 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
-
   t.throws(testFunc, Error, getMsg(`CLOUD_BUCKET`));
   nconfMock.CLOUD_BUCKET = `bucket`;
 

--- a/4-auth/books/model-datastore.js
+++ b/4-auth/books/model-datastore.js
@@ -14,11 +14,8 @@
 'use strict';
 
 const Datastore = require('@google-cloud/datastore');
-const config = require('../config');
 
-const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const ds = Datastore();
 const kind = 'Book';
 
 // Translates from Datastore's entity format to

--- a/4-auth/config.js
+++ b/4-auth/config.js
@@ -25,7 +25,6 @@ nconf
   .env([
     'CLOUD_BUCKET',
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
     'MEMCACHE_URL',
     'MEMCACHE_USERNAME',
     'MEMCACHE_PASSWORD',
@@ -52,9 +51,6 @@ nconf
     // configuration.
     DATA_BACKEND: 'datastore',
 
-    // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
-
     MYSQL_USER: '',
     MYSQL_PASSWORD: '',
 
@@ -69,7 +65,6 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 checkConfig('OAUTH2_CLIENT_ID');
 checkConfig('OAUTH2_CLIENT_SECRET');

--- a/4-auth/lib/images.js
+++ b/4-auth/lib/images.js
@@ -18,9 +18,7 @@ const config = require('../config');
 
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
-const storage = Storage({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const storage = Storage();
 const bucket = storage.bucket(CLOUD_BUCKET);
 
 // Returns the public, anonymously accessable URL to a given Cloud Storage

--- a/4-auth/test/_test-config.js
+++ b/4-auth/test/_test-config.js
@@ -28,6 +28,5 @@ module.exports = {
   },
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
   msg: `Bookshelf`,
 };

--- a/4-auth/test/app.test.js
+++ b/4-auth/test/app.test.js
@@ -51,9 +51,6 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
-
   t.throws(testFunc, Error, getMsg(`CLOUD_BUCKET`));
   nconfMock.CLOUD_BUCKET = `bucket`;
 

--- a/5-logging/books/model-datastore.js
+++ b/5-logging/books/model-datastore.js
@@ -14,11 +14,8 @@
 'use strict';
 
 const Datastore = require('@google-cloud/datastore');
-const config = require('../config');
 
-const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const ds = Datastore();
 const kind = 'Book';
 
 // Translates from Datastore's entity format to

--- a/5-logging/config.js
+++ b/5-logging/config.js
@@ -25,7 +25,6 @@ nconf
   .env([
     'CLOUD_BUCKET',
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
     'MEMCACHE_URL',
     'MEMCACHE_USERNAME',
     'MEMCACHE_PASSWORD',
@@ -52,9 +51,6 @@ nconf
     // configuration.
     DATA_BACKEND: 'datastore',
 
-    // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
-
     MYSQL_USER: '',
     MYSQL_PASSWORD: '',
 
@@ -69,7 +65,6 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 checkConfig('OAUTH2_CLIENT_ID');
 checkConfig('OAUTH2_CLIENT_SECRET');

--- a/5-logging/lib/images.js
+++ b/5-logging/lib/images.js
@@ -18,9 +18,7 @@ const config = require('../config');
 
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
-const storage = Storage({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const storage = Storage();
 const bucket = storage.bucket(CLOUD_BUCKET);
 
 // Returns the public, anonymously accessable URL to a given Cloud Storage

--- a/5-logging/test/_test-config.js
+++ b/5-logging/test/_test-config.js
@@ -28,6 +28,5 @@ module.exports = {
   },
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
   msg: `Bookshelf`,
 };

--- a/5-logging/test/app.test.js
+++ b/5-logging/test/app.test.js
@@ -51,9 +51,6 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
-
   t.throws(testFunc, Error, getMsg(`CLOUD_BUCKET`));
   nconfMock.CLOUD_BUCKET = `bucket`;
 

--- a/6-pubsub/books/model-datastore.js
+++ b/6-pubsub/books/model-datastore.js
@@ -14,12 +14,9 @@
 'use strict';
 
 const Datastore = require('@google-cloud/datastore');
-const config = require('../config');
 const background = require('../lib/background');
 
-const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const ds = Datastore();
 const kind = 'Book';
 
 // Translates from Datastore's entity format to

--- a/6-pubsub/config.js
+++ b/6-pubsub/config.js
@@ -25,7 +25,6 @@ nconf
   .env([
     'CLOUD_BUCKET',
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
     'MEMCACHE_URL',
     'MEMCACHE_USERNAME',
     'MEMCACHE_PASSWORD',
@@ -53,9 +52,6 @@ nconf
     // configuration.
     DATA_BACKEND: 'datastore',
 
-    // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
-
     // Connection url for the Memcache instance used to store session data
     MEMCACHE_URL: 'localhost:11211',
 
@@ -75,7 +71,6 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 checkConfig('OAUTH2_CLIENT_ID');
 checkConfig('OAUTH2_CLIENT_SECRET');

--- a/6-pubsub/lib/background.js
+++ b/6-pubsub/lib/background.js
@@ -19,9 +19,7 @@ const logging = require('./logging');
 
 const topicName = config.get('TOPIC_NAME');
 
-const pubsub = new PubSub({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const pubsub = new PubSub();
 
 // This configuration will automatically create the topic if
 // it doesn't yet exist. Usually, you'll want to make sure

--- a/6-pubsub/lib/images.js
+++ b/6-pubsub/lib/images.js
@@ -20,9 +20,7 @@ const logging = require('./logging');
 
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
-const storage = Storage({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const storage = Storage();
 const bucket = storage.bucket(CLOUD_BUCKET);
 
 // Downloads a given image (by URL) and then uploads it to

--- a/6-pubsub/test/_test-config.js
+++ b/6-pubsub/test/_test-config.js
@@ -26,7 +26,6 @@ module.exports = {
   port: PORT,
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
   env: {
     PORT: PORT,
     TOPIC_NAME: `book-process-queue-${TESTNAME}`,

--- a/6-pubsub/test/_test-config.worker.js
+++ b/6-pubsub/test/_test-config.worker.js
@@ -14,10 +14,10 @@
 'use strict';
 
 const path = require(`path`);
-const PROJECT_ID = process.env.GCLOUD_PROJECT;
 const TESTNAME = `6-pubsub`;
 const PORT = 8091;
 const VERSION = `${process.env.GAE_VERSION || TESTNAME}`;
+const PROJECT_ID = process.env.GCLOUD_PROJECT;
 
 module.exports = {
   test: TESTNAME,
@@ -31,7 +31,6 @@ module.exports = {
     TOPIC_NAME: `book-process-queue-${TESTNAME}`,
   },
   version: VERSION,
-  project: PROJECT_ID,
 };
 
 if (process.env.E2E_TESTS) {

--- a/6-pubsub/test/app.test.js
+++ b/6-pubsub/test/app.test.js
@@ -51,9 +51,6 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
-
   t.throws(testFunc, Error, getMsg(`CLOUD_BUCKET`));
   nconfMock.CLOUD_BUCKET = `bucket`;
 

--- a/6-pubsub/test/background.test.js
+++ b/6-pubsub/test/background.test.js
@@ -23,7 +23,6 @@ const mocks = {};
 test.beforeEach(t => {
   // Mock dependencies used by background.js
   mocks.config = {
-    GCLOUD_PROJECT: process.env.GCLOUD_PROJECT,
     SUBSCRIPTION_NAME: `shared-worker-subscription`,
     TOPIC_NAME: `book-process-queue`,
   };

--- a/7-gce/README.md
+++ b/7-gce/README.md
@@ -43,8 +43,6 @@ and deploying this sample.
 
         cp config-default.json config.json
 
-    * Set `GCLOUD_PROJECT` in `config.json` to your Google Cloud Platform
-      project ID.
     * Set `DATA_BACKEND` in `config.json` to one of `"datastore"`, `"cloudsql"`,
       or `"mongodb"`.
     * Set `CLOUD_BUCKET` in `config.json` to the name of your Google Cloud

--- a/7-gce/books/model-datastore.js
+++ b/7-gce/books/model-datastore.js
@@ -14,12 +14,9 @@
 'use strict';
 
 const Datastore = require('@google-cloud/datastore');
-const config = require('../config');
 const background = require('../lib/background');
 
-const ds = Datastore({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const ds = Datastore();
 const kind = 'Book';
 
 // Translates from Datastore's entity format to

--- a/7-gce/config.js
+++ b/7-gce/config.js
@@ -25,7 +25,6 @@ nconf
   .env([
     'CLOUD_BUCKET',
     'DATA_BACKEND',
-    'GCLOUD_PROJECT',
     'MEMCACHE_URL',
     'MONGO_URL',
     'MONGO_COLLECTION',
@@ -55,9 +54,6 @@ nconf
     // configuration.
     DATA_BACKEND: 'datastore',
 
-    // This is the id of your project in the Google Cloud Developers Console.
-    GCLOUD_PROJECT: '',
-
     // Connection url for the Memcache instance used to store session data
     MEMCACHE_URL: 'localhost:11211',
 
@@ -83,7 +79,6 @@ nconf
   });
 
 // Check for required settings
-checkConfig('GCLOUD_PROJECT');
 checkConfig('CLOUD_BUCKET');
 checkConfig('OAUTH2_CLIENT_ID');
 checkConfig('OAUTH2_CLIENT_SECRET');

--- a/7-gce/lib/background.js
+++ b/7-gce/lib/background.js
@@ -20,9 +20,7 @@ const logging = require('./logging');
 const topicName = config.get('TOPIC_NAME');
 const subscriptionName = config.get('SUBSCRIPTION_NAME');
 
-const pubsub = new PubSub({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const pubsub = new PubSub();
 
 // This configuration will automatically create the topic if
 // it doesn't yet exist. Usually, you'll want to make sure

--- a/7-gce/lib/images.js
+++ b/7-gce/lib/images.js
@@ -20,9 +20,7 @@ const logging = require('./logging');
 
 const CLOUD_BUCKET = config.get('CLOUD_BUCKET');
 
-const storage = Storage({
-  projectId: config.get('GCLOUD_PROJECT'),
-});
+const storage = Storage();
 const bucket = storage.bucket(CLOUD_BUCKET);
 
 // Downloads a given image (by URL) and then uploads it to

--- a/7-gce/test/_test-config.js
+++ b/7-gce/test/_test-config.js
@@ -26,7 +26,6 @@ module.exports = {
   port: PORT,
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
-  project: process.env.GCLOUD_PROJECT,
   env: {
     PORT: PORT,
     SUBSCRIPTION_NAME: `shared-worker-subscription-${TESTNAME}`,

--- a/7-gce/test/_test-config.worker.js
+++ b/7-gce/test/_test-config.worker.js
@@ -14,10 +14,10 @@
 'use strict';
 
 const path = require(`path`);
-const PROJECT_ID = process.env.GCLOUD_PROJECT;
 const TESTNAME = `7-gce`;
 const PORT = 8092;
 const VERSION = `${process.env.GAE_VERSION || TESTNAME}`;
+const PROJECT_ID = process.env.GCLOUD_PROJECT;
 
 module.exports = {
   test: TESTNAME,
@@ -32,7 +32,6 @@ module.exports = {
     TOPIC_NAME: `book-process-queue-${TESTNAME}`,
   },
   version: VERSION,
-  project: PROJECT_ID,
 };
 
 if (process.env.E2E_TESTS) {

--- a/7-gce/test/app.test.js
+++ b/7-gce/test/app.test.js
@@ -51,9 +51,6 @@ test(`should check config`, t => {
 
   nconfMock.DATA_BACKEND = `datastore`;
 
-  t.throws(testFunc, Error, getMsg(`GCLOUD_PROJECT`));
-  nconfMock.GCLOUD_PROJECT = `project`;
-
   t.throws(testFunc, Error, getMsg(`CLOUD_BUCKET`));
   nconfMock.CLOUD_BUCKET = `bucket`;
 

--- a/7-gce/test/background.test.js
+++ b/7-gce/test/background.test.js
@@ -23,7 +23,6 @@ const mocks = {};
 test.beforeEach(t => {
   // Mock dependencies used by background.js
   mocks.config = {
-    GCLOUD_PROJECT: process.env.GCLOUD_PROJECT,
     SUBSCRIPTION_NAME: `shared-worker-subscription`,
     TOPIC_NAME: `book-process-queue`,
   };


### PR DESCRIPTION
Locally, users should use GOOGLE_APPLICATION_CREDENTIALS. On GCP,
the metadata is used autmatically.

This commit does not change the GKE sample.

Ref: https://github.com/GoogleCloudPlatform/nodejs-getting-started/issues/251