### PR TITLE
Use oauth userinfo instead of Google+ profile

### DIFF
--- a/4-auth/lib/oauth2.js
+++ b/4-auth/lib/oauth2.js
@@ -46,6 +46,7 @@ passport.use(
       clientSecret: config.get('OAUTH2_CLIENT_SECRET'),
       callbackURL: config.get('OAUTH2_CALLBACK'),
       accessType: 'offline',
+      userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo',
     },
     (accessToken, refreshToken, profile, cb) => {
       // Extract the minimal profile information we need from the profile object

--- a/5-logging/lib/oauth2.js
+++ b/5-logging/lib/oauth2.js
@@ -46,6 +46,7 @@ passport.use(
       clientSecret: config.get('OAUTH2_CLIENT_SECRET'),
       callbackURL: config.get('OAUTH2_CALLBACK'),
       accessType: 'offline',
+      userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo',
     },
     (accessToken, refreshToken, profile, cb) => {
       // Extract the minimal profile information we need from the profile object

--- a/6-pubsub/lib/oauth2.js
+++ b/6-pubsub/lib/oauth2.js
@@ -46,6 +46,7 @@ passport.use(
       clientSecret: config.get('OAUTH2_CLIENT_SECRET'),
       callbackURL: config.get('OAUTH2_CALLBACK'),
       accessType: 'offline',
+      userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo',
     },
     (accessToken, refreshToken, profile, cb) => {
       // Extract the minimal profile information we need from the profile object

--- a/7-gce/lib/oauth2.js
+++ b/7-gce/lib/oauth2.js
@@ -46,6 +46,7 @@ passport.use(
       clientSecret: config.get('OAUTH2_CLIENT_SECRET'),
       callbackURL: config.get('OAUTH2_CALLBACK'),
       accessType: 'offline',
+      userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo',
     },
     (accessToken, refreshToken, profile, cb) => {
       // Extract the minimal profile information we need from the profile object

--- a/optional-kubernetes-engine/lib/oauth2.js
+++ b/optional-kubernetes-engine/lib/oauth2.js
@@ -46,6 +46,7 @@ passport.use(
       clientSecret: config.get('OAUTH2_CLIENT_SECRET'),
       callbackURL: config.get('OAUTH2_CALLBACK'),
       accessType: 'offline',
+      userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo',
     },
     (accessToken, refreshToken, profile, cb) => {
       // Extract the minimal profile information we need from the profile object


### PR DESCRIPTION
Passport.js uses Google+ as default for the Google Strategy. Use oauth `userinfo` instead.