### PR TITLE
Fix e2e tests

### DIFF
--- a/.kokoro/e2e-tests/build.sh
+++ b/.kokoro/e2e-tests/build.sh
@@ -29,7 +29,7 @@ export NVM_DIR="$HOME/.nvm"
 nvm install 10
 
 export NODE_ENV=development
-export E2E_TESTS=true # test the deployed app
+export E2E_TESTS=true # test the deployed app, used by repo-tools.getRequest()
 
 # Register post-test cleanup
 export GAE_VERSION=${BOOKSHELF_DIRECTORY:0:1}-${DATA_BACKEND}
@@ -54,13 +54,15 @@ function cleanup {
 trap cleanup EXIT
 
 # Configure gcloud
+# Export the project as repo-tools e2e tests rely on it:
+# `https://${opts.version}-dot-${opts.project}.appspot.com`.
 export GCLOUD_PROJECT=nodejs-getting-started-tests
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/secrets-key.json
 gcloud auth activate-service-account --key-file "$GOOGLE_APPLICATION_CREDENTIALS"
 gcloud config set project $GCLOUD_PROJECT
 
 # Install Node dependencies
-yarn global add @google-cloud/nodejs-repo-tools
+npm i -g @google-cloud/nodejs-repo-tools
 cd github/nodejs-getting-started/${BOOKSHELF_DIRECTORY}
 
 # Copy secrets
@@ -68,7 +70,7 @@ cp ${KOKORO_GFILE_DIR}/secrets-config.json config.json
 cp $GOOGLE_APPLICATION_CREDENTIALS key.json
 
 # Install dependencies (for running the tests, not the apps themselves)
-yarn install
+npm install
 
 # Deploy a single step
 gcloud app deploy --version $GAE_VERSION --no-promote # nodejs-repo-tools doesn't support specifying versions, so deploy manually

--- a/2-structured-data/test/_test-config.js
+++ b/2-structured-data/test/_test-config.js
@@ -29,4 +29,5 @@ module.exports = {
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
   msg: `Bookshelf`,
+  project: process.env.GCLOUD_PROJECT, // needed for e2e URL
 };

--- a/3-binary-data/test/_test-config.js
+++ b/3-binary-data/test/_test-config.js
@@ -29,4 +29,5 @@ module.exports = {
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
   msg: `Bookshelf`,
+  project: process.env.GCLOUD_PROJECT, // needed for e2e URL
 };

--- a/4-auth/test/_test-config.js
+++ b/4-auth/test/_test-config.js
@@ -29,4 +29,5 @@ module.exports = {
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
   msg: `Bookshelf`,
+  project: process.env.GCLOUD_PROJECT, // needed for e2e URL
 };

--- a/5-logging/test/_test-config.js
+++ b/5-logging/test/_test-config.js
@@ -29,4 +29,5 @@ module.exports = {
   url: `http://localhost:${PORT}`,
   version: process.env.GAE_VERSION || TESTNAME,
   msg: `Bookshelf`,
+  project: process.env.GCLOUD_PROJECT, // needed for e2e URL
 };

--- a/6-pubsub/test/_test-config.js
+++ b/6-pubsub/test/_test-config.js
@@ -30,4 +30,5 @@ module.exports = {
     PORT: PORT,
     TOPIC_NAME: `book-process-queue-${TESTNAME}`,
   },
+  project: process.env.GCLOUD_PROJECT, // needed for e2e URL
 };

--- a/7-gce/test/_test-config.js
+++ b/7-gce/test/_test-config.js
@@ -31,4 +31,5 @@ module.exports = {
     SUBSCRIPTION_NAME: `shared-worker-subscription-${TESTNAME}`,
     TOPIC_NAME: `book-process-queue-${TESTNAME}`,
   },
+  project: process.env.GCLOUD_PROJECT, // needed for e2e URL
 };


### PR DESCRIPTION
e2e tests send request against the live app living at
`https://${opts.version}-dot-${opts.project}.appspot.com`;

The test config relies on `opts.project`, which we configure via
an environment variable.

Note that only our tests use $GCLOUD_PROJECT, it is not used in the app.