### PR TITLE
fix firestore session config example issue

### DIFF
--- a/sessions/index.js
+++ b/sessions/index.js
@@ -21,9 +21,8 @@ const {FirestoreStore} = require('@google-cloud/connect-firestore');
 app.use(
   session({
     store: new FirestoreStore({
-      dataset: new Firestore({
-        kind: 'express-sessions',
-      }),
+      dataset: new Firestore(),
+      kind: 'express-sessions',
     }),
     secret: 'my-secret',
     resave: false,


### PR DESCRIPTION
The Collection (kind) must be configured in the StoreOptions of the FirestoreStore and not in the settings of the Firestore.

https://github.com/googleapis/nodejs-firestore-session#using-the-client-library