### PR TITLE
test: increase timeout

### DIFF
--- a/bookshelf/package.json
+++ b/bookshelf/package.json
@@ -11,7 +11,7 @@
   "private": true,
   "scripts": {
     "start": "node app.js",
-    "test": "mocha --exit **/*.test.js"
+    "test": "mocha --timeout=8000 --exit **/*.test.js"
   },
   "dependencies": {
     "@google-cloud/firestore": "^4.0.0",


### PR DESCRIPTION
Bumped into an intermittent test failure:

```
Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/tmpfs/src/github/nodejs-getting-started/bookshelf/test/app.test.js)
Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/tmpfs/src/github/nodejs-getting-started/bookshelf/test/app.test.js)
```

Not guaranteed to solve the problem, but 2s seems a little short, let's extend as a first step into investigation.

Fixes #480
Fixes #479
Fixes #478