### PR TITLE
build: build.sh should fail early if any command fails

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 export GCLOUD_PROJECT='firestore-nodejs-getting-start'
 export REGION_ID='uc'
 


### PR DESCRIPTION
See #485 

The script should fail when it tries activating the credentials and never even start running the tests.