### PR TITLE
Update GCE sample to Node.js v16.15.0

### DIFF
--- a/gce/startup-script.sh
+++ b/gce/startup-script.sh
@@ -34,7 +34,7 @@ apt-get install -yq ca-certificates git build-essential supervisor
 
 # Install nodejs
 mkdir /opt/nodejs
-curl https://nodejs.org/dist/v8.12.0/node-v8.12.0-linux-x64.tar.gz | tar xvzf - -C /opt/nodejs --strip-components=1
+curl https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-x64.tar.gz | tar xvzf - -C /opt/nodejs --strip-components=1
 ln -s /opt/nodejs/bin/node /usr/bin/node
 ln -s /opt/nodejs/bin/npm /usr/bin/npm
 

--- a/gce/startup-script.sh
+++ b/gce/startup-script.sh
@@ -69,3 +69,4 @@ supervisorctl reread
 supervisorctl update
 
 # Application should now be running under supervisor
+# [END startup]


### PR DESCRIPTION
Updates the GCE sample app to use Node.js v16.15.0. Currently it uses
v8.12.0, which is no longer supported.

Fixes #541 